### PR TITLE
Add bottom tabs for direct access to the top-level screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { NavigationContainer } from '@react-navigation/native';
+
 import CoursesScreen from './src/screens/CoursesScreen';
 import AddCourseScreen from './src/screens/AddCourseScreen';
 import TimeTable from './src/screens/TimetableScreen';
+
+import BottomTabs from './src/components/BottomTabs';
 
 const Stack = createNativeStackNavigator();
 
@@ -21,11 +24,16 @@ export default function App() {
           },
           headerTitleAlign: 'center',
         }}>
+        <Stack.Screen
+          name='Bottom Tabs'
+          component={BottomTabs}
+          options={{ headerShown: false }}
+        />
         <Stack.Screen name="Courses" component={CoursesScreen} />
         <Stack.Screen name="Add Course" component={AddCourseScreen} />
-        <Stack.Screen name="Time Table" component={TimeTable} />
+        <Stack.Screen name="Timetable" component={TimeTable} />
         {/* Other screens */}
       </Stack.Navigator>
-    </NavigationContainer>
+      </NavigationContainer>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.21.0",
         "@react-native-community/cli-platform-android": "^12.3.0",
+        "@react-navigation/bottom-tabs": "^6.5.11",
         "@react-navigation/native": "^6.1.9",
         "@react-navigation/native-stack": "^6.9.17",
         "@react-navigation/stack": "^6.3.20",
@@ -4302,6 +4303,23 @@
       },
       "peerDependencies": {
         "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.5.11.tgz",
+      "integrity": "sha512-CBN/NOdxnMvmjw+AJQI1kltOYaClTZmGec5pQ3ZNTPX86ytbIOylDIITKMfTgHZcIEFQDymx1SHeS++PIL3Szw==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.21",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
       }
     },
     "node_modules/@react-navigation/core": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.21.0",
     "@react-native-community/cli-platform-android": "^12.3.0",
+    "@react-navigation/bottom-tabs": "^6.5.11",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
     "@react-navigation/stack": "^6.3.20",

--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -1,0 +1,29 @@
+import { ComponentType } from "react";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"; 
+
+import CoursesScreen from "../screens/CoursesScreen";
+import TimeTable from "../screens/TimetableScreen";
+
+const Tab = createBottomTabNavigator();
+
+interface TabScreen {
+  name: string,
+  component: ComponentType<any>;
+}
+
+function BottomTabs() {
+  const screens: TabScreen[] = [
+    { name: 'Courses', component: CoursesScreen},
+    { name: 'Timetable', component: TimeTable},
+  ];
+
+  return (
+    <Tab.Navigator>
+      {screens.map((screen) => (
+        <Tab.Screen key={screen.name} name={screen.name} component={screen.component} />
+      ))} 
+    </Tab.Navigator>
+  )
+}
+
+export default BottomTabs;


### PR DESCRIPTION
This seems to be way faster than implementing our own tabs like in the calculator.

- New package: `@react-navigation/bottom-tabs`