### PR TITLE
Add dev menu screen prototype

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import AddCourseScreen from './src/screens/AddCourseScreen';
 import EditCourseScreen from './src/screens/EditCourseScreen';
 import CourseDetailsScreen from './src/screens/CourseDetailsScreen';
 import TimeTable from './src/screens/TimetableScreen';
+import DevMenuScreen from './src/screens/DevMenuScreen'
 
 import BottomTabs from './src/components/BottomTabs';
 
@@ -36,6 +37,9 @@ export default function App() {
         <Stack.Screen name="Course Details" component={CourseDetailsScreen} />
         <Stack.Screen name="Edit Course" component={EditCourseScreen} />
         <Stack.Screen name="Timetable" component={TimeTable} />
+        {__DEV__ && (
+          <Stack.Screen name="Dev Menu" component={DevMenuScreen} />
+        )}
         {/* Other screens */}
       </Stack.Navigator>
       </NavigationContainer>

--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -5,6 +5,7 @@ import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import CoursesScreen from '../screens/CoursesScreen';
 import TimeTable from '../screens/TimetableScreen';
+import DevMenuScreen from '../screens/DevMenuScreen';
 
 const Tab = createBottomTabNavigator();
 
@@ -35,6 +36,14 @@ const screens: TabScreenProps[] = [
   },
 ];
 
+const devScreens: TabScreenProps[] = [
+  {
+    name: 'Dev Menu',
+    component: DevMenuScreen,
+    options: {},
+  },
+];
+
 function BottomTabs() {
   return (
     <Tab.Navigator
@@ -49,6 +58,14 @@ function BottomTabs() {
         headerTitleAlign: 'center',
       }}>
       {screens.map((screen) => (
+        <Tab.Screen
+          key={screen.name}
+          name={screen.name}
+          component={screen.component}
+          options={screen.options}
+        />
+      ))}
+      {__DEV__ && devScreens.map((screen) => (
         <Tab.Screen
           key={screen.name}
           name={screen.name}

--- a/src/screens/DevMenuScreen.tsx
+++ b/src/screens/DevMenuScreen.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+
+interface DevMenuScreenProps {
+  navigation: any;
+}
+
+const DevMenuScreen: React.FC<DevMenuScreenProps> = ({ navigation }) => {
+  return (
+    <View style={{ flex: 1 }}>
+      <TouchableOpacity>
+        <View style={styles.button}>
+          <Text style={{ color: 'white' }}>Populate Database</Text>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity>
+        <View style={styles.button}>
+          <Text style={{ color: 'white' }}>Inspect Database</Text>
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity>
+        <View style={styles.button}>
+          <Text style={{ color: 'white' }}>Clear Database</Text>
+        </View>
+      </TouchableOpacity>
+      <View style={{ flexGrow: 1, borderWidth: 2, margin: 20 }}>
+        <Text style={{ color: 'black', fontSize: 24 }}>output erea</Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: '#1e90ff',
+    borderWidth: 1,
+    borderColor: 'black',
+    borderRadius: 5,
+    marginTop: 20,
+    marginHorizontal: 20,
+    padding: 10,
+  },
+});
+
+export default DevMenuScreen;


### PR DESCRIPTION
This is a prototype for the Dev Menu screen and does not represent the final design and layout of the Dev Menu screen.

**NOTE**: This screen is only available in the development build of the app.

![image](https://github.com/maqnitude/uit-planner/assets/108073174/968fe0e6-cf30-427b-a84c-1e397d58ca58)
